### PR TITLE
Fix seneca-web references (fixes #11)

### DIFF
--- a/api-all.js
+++ b/api-all.js
@@ -3,24 +3,32 @@ module.exports = function api( options ) {
   var valid_ops = { sum:'sum', product:'product' }
 
   this.add( 'role:api,path:calculate', function( msg, respond ) {
+    var left = msg.args.query.left
+    var right = msg.args.query.right
+    var operation = msg.args.params.operation
     this.act( 'role:math', {
-      cmd:   valid_ops[msg.operation],
-      left:  msg.left,
-      right: msg.right,
+      cmd:   valid_ops[operation],
+      left:  left,
+      right: right,
     }, respond )
   })
 
   this.add( 'role:api,path:shop', function( msg, respond ) {
-    var shopmsg = { role:'shop', id:msg.pid }
-    if( 'get'      == msg.operation ) shopmsg.get = 'product'
-    if( 'purchase' == msg.operation ) shopmsg.cmd = 'purchase'
+    var id = null
+    if (msg.args.query.pid) { id = msg.args.query.pid}
+    if (msg.args.body.pid) { id = msg.args.body.pid}
+
+    var operation = msg.args.params.operation
+    var shopmsg = { role:'shop', id:id }
+    if( 'get'      == operation ) shopmsg.get = 'product'
+    if( 'purchase' == operation ) shopmsg.cmd = 'purchase'
 
     this.act( shopmsg, respond )
   })
 
 
   this.add( 'init:api', function( msg, respond ) {
-    this.act('role:web',{use:{
+    this.act('role:web',{routes:{
       prefix: '/api',
       pin:    'role:api,path:*',
       map: {
@@ -28,7 +36,7 @@ module.exports = function api( options ) {
       }
     }})
 
-    this.act('role:web',{use:{
+    this.act('role:web',{routes:{
       prefix: '/api',
       pin:    'role:api,path:*',
       map: {

--- a/api.js
+++ b/api.js
@@ -3,16 +3,19 @@ module.exports = function api( options ) {
   var valid_ops = { sum:'sum', product:'product' }
 
   this.add( 'role:api,path:calculate', function( msg, respond ) {
+    var operation = msg.args.params.operation
+    var left = msg.args.query.left
+    var right = msg.args.query.right
     this.act( 'role:math', {
-      cmd:   valid_ops[msg.operation],
-      left:  msg.left,
-      right: msg.right,
+      cmd:   valid_ops[operation],
+      left:  left,
+      right: right,
     }, respond )
   })
 
   
   this.add( 'init:api', function( msg, respond ) {
-    this.act('role:web',{use:{
+    this.act('role:web',{routes:{
       prefix: '/api',
       pin:    'role:api,path:*',
       map: {

--- a/app-all.js
+++ b/app-all.js
@@ -1,4 +1,5 @@
 
+var SenecaWeb = require('seneca-web')
 var Express = require('express')
 var Router = Express.Router
 var context = new Router()
@@ -15,7 +16,7 @@ var app = Express()
       .listen(3000)
 
 var seneca = require( 'seneca' )()
-      .use( 'seneca-web', senecaWebConfig )
+      .use( SenecaWeb, senecaWebConfig )
       .use( 'entity' )
       .use( 'api-all' )
       .client( { type:'tcp', pin:'role:math' } )

--- a/app-all.js
+++ b/app-all.js
@@ -1,14 +1,25 @@
 
+var Express = require('express')
+var Router = Express.Router
+var context = new Router()
+
+var senecaWebConfig = {
+      context: context,
+      adapter: require('seneca-web-adapter-express'),
+      options: { parseBody: false } // so we can use body-parser
+}
+
+var app = Express()
+      .use( require('body-parser').json() )
+      .use( context )
+      .listen(3000)
+
 var seneca = require( 'seneca' )()
-      .use('entity')
+      .use( 'seneca-web', senecaWebConfig )
+      .use( 'entity' )
       .use( 'api-all' )
       .client( { type:'tcp', pin:'role:math' } )
       .client( { port:9002,  pin:'role:shop' } )
-
-var app = require( 'express' )()
-      .use( require('body-parser').json() )
-      .use( seneca.export( 'web' ) )
-      .listen(3000)
 
 // create a dummy product
 seneca.act(

--- a/app.js
+++ b/app.js
@@ -1,4 +1,5 @@
 
+var SenecaWeb = require('seneca-web')
 var Express = require('express')
 var Router = Express.Router
 var context = new Router()
@@ -15,7 +16,7 @@ var app = Express()
       .listen(3000)
 
 var seneca = require( 'seneca' )()
-      .use( 'seneca-web', senecaWebConfig )
+      .use( SenecaWeb, senecaWebConfig )
       .use( 'api' )
       .client( { type:'tcp', pin:'role:math' } )
 

--- a/app.js
+++ b/app.js
@@ -1,11 +1,23 @@
 
+var Express = require('express')
+var Router = Express.Router
+var context = new Router()
+
+var senecaWebConfig = {
+      context: context,
+      adapter: require('seneca-web-adapter-express'),
+      options: { parseBody: false } // so we can use body-parser
+}
+
+var app = Express()
+      .use( require('body-parser').json() )
+      .use( context )
+      .listen(3000)
+
 var seneca = require( 'seneca' )()
+      .use( 'seneca-web', senecaWebConfig )
       .use( 'api' )
       .client( { type:'tcp', pin:'role:math' } )
 
-var app = require( 'express' )()
-      .use( require('body-parser').json() )
-      .use( seneca.export( 'web' ) )
-      .listen(3000)
 
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "body-parser": "^1.13.2",
     "express": "^4.13.1",
     "seneca": "2.0.0",
-    "seneca-entity": "0.0.1"
+    "seneca-entity": "0.0.1",
+    "seneca-web": "^2.0.0",
+    "seneca-web-adapter-express": "^1.0.2"
   }
 }


### PR DESCRIPTION
Notable changes

- added dependencies to seneca-web and seneca-web-adapter-express
- need to explicitly use `seneca-web`
- `use` is now `routes`
- msg no longer includes most things, need to explicitly look at `msg.args.body`, `msg.args.query`, `msg.args.params`, etc.

I've tried each of these now with `node app.js` and `node app-all.js` and tried it out - everything seems to be working.  